### PR TITLE
PermissionOverwritesを更新

### DIFF
--- a/index.js
+++ b/index.js
@@ -652,7 +652,9 @@ client.on('interactionCreate', async(interaction) => {
           parent: ct.id
       }).then(channels => {
           channels.permissionOverwrites.edit(interaction.user.id, {
-              VIEW_CHANNEL: true
+              VIEW_CHANNEL: true,
+              SEND_MESSAGES: true,
+              ADD_REACTIONS: true
           });
           const tic2 = new MessageButton().setCustomId("close").setStyle("PRIMARY").setLabel("閉じる");
           //buttonを作成


### PR DESCRIPTION
サポ鯖のチャンネル整理時、everyoneから送信・リアクション等を切ったので、チケット作成者に新たに
・メッセージを送信
・リアクション
権限を付けました。